### PR TITLE
added minimal pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Adding a minimal pyproject.toml file to print "pip install ." into compliance with (see https://packaging.python.org/en/latest/guides/modernize-setup-py-project/). This is still compatible with having a setup.py file.